### PR TITLE
Allow more flexible type checks on duration

### DIFF
--- a/traces/utils.py
+++ b/traces/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import numbers
 
 from infinity import inf
 
@@ -11,7 +12,7 @@ def duration_to_number(duration, units="seconds"):
     TODO: allow for multiple types of units.
 
     """
-    if isinstance(duration, (int, float)):
+    if isinstance(duration, (numbers.Integral, numbers.Real)):
         return duration
     elif isinstance(duration, (datetime.timedelta,)):
         if units == "seconds":


### PR DESCRIPTION
The current way of checking `int` and `float` cannot handle numpy's data types, such as `np.int64` and `np.float64`, which requires extra effort to convert a numpy element into `int` or `float` to pass the check.

Using numeric ABCs solves the problem and allows more flexible "implementations" of integers and real numbers. (Better than the approach in #224, no extra dependencies needed)

=== Updated ===
Tests can be passed locally.
CI seems to complain something about `repo_token` and marked them as failed.